### PR TITLE
Generic IO methods

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -76,8 +76,8 @@ const VIRTIO_PCI_VENDOR_ID: u16 = 0x1af4;
 #[cfg(not(test))]
 const VIRTIO_PCI_BLOCK_DEVICE_ID: u16 = 0x1042;
 
-#[cfg(not(test))]
 #[no_mangle]
+#[cfg(not(test))]
 pub extern "C" fn _start() -> ! {
     unsafe {
         asm!("movq $$0x180000, %rsp");

--- a/src/mem.rs
+++ b/src/mem.rs
@@ -12,9 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// TODO(rbradford): Use generics ?
-
 #![allow(dead_code)]
+
 #[derive(Default)]
 /// Provides a checked way to access memory offsets from a range of raw memory
 pub struct MemoryRegion {
@@ -41,52 +40,56 @@ impl MemoryRegion {
         unsafe { core::slice::from_raw_parts_mut((self.base + offset) as *mut T, length as usize) }
     }
 
+    /// Read a value from a given offset
+    fn read<T>(&self, offset: u64) -> T
+    where
+        T: Copy,
+    {
+        assert!((offset + (core::mem::size_of::<T>() - 1) as u64) < self.length);
+        unsafe { *((self.base + offset) as *const T) }
+    }
+
     /// Read a single byte at a given offset
     pub fn read_u8(&self, offset: u64) -> u8 {
-        assert!(offset < self.length);
-        unsafe { *((self.base + offset) as *const u8) }
+        self.read(offset)
     }
 
     /// Read a single word at a given offset
     pub fn read_u16(&self, offset: u64) -> u16 {
-        assert!(offset + 1 < self.length);
-        unsafe { *((self.base + offset) as *const u16) }
+        self.read(offset)
     }
 
     /// Read a single dword at a given offset
     pub fn read_u32(&self, offset: u64) -> u32 {
-        assert!(offset + 3 < self.length);
-        unsafe { *((self.base + offset) as *const u32) }
+        self.read(offset)
     }
 
     // Read a single qword at a given offset
     pub fn read_u64(&self, offset: u64) -> u64 {
-        assert!(offset + 7 < self.length);
-        unsafe { *((self.base + offset) as *const u64) }
+        self.read(offset)
+    }
+
+    /// Write a value at the given offset
+    pub fn write<T>(&self, offset: u64, value: T) {
+        assert!((offset + (core::mem::size_of::<T>() - 1) as u64) < self.length);
+        unsafe {
+            *((self.base + offset) as *mut T) = value;
+        }
     }
 
     /// Write a single byte at given offset
     pub fn write_u8(&self, offset: u64, value: u8) {
-        assert!(offset < self.length);
-        unsafe {
-            *((self.base + offset) as *mut u8) = value;
-        }
+        self.write(offset, value)
     }
 
     /// Write a single word at given offset
     pub fn write_u16(&self, offset: u64, value: u16) {
-        assert!(offset + 1 < self.length);
-        unsafe {
-            *((self.base + offset) as *mut u16) = value;
-        }
+        self.write(offset, value)
     }
 
     /// Write a single dword at given offset
     pub fn write_u32(&self, offset: u64, value: u32) {
-        assert!(offset + 3 < self.length);
-        unsafe {
-            *((self.base + offset) as *mut u32) = value;
-        }
+        self.write(offset, value)
     }
 
     /// Write a single qword at given offset
@@ -97,59 +100,57 @@ impl MemoryRegion {
         }
     }
 
+    /// Read a value at given offset with a mechanism suitable for MMIO
+    fn io_read<T>(&self, offset: u64) -> T {
+        assert!((offset + (core::mem::size_of::<T>() - 1) as u64) < self.length);
+        unsafe { core::ptr::read_volatile((self.base + offset) as *const T) }
+    }
+
     /// Read a single byte at given offset with a mechanism suitable for MMIO
     pub fn io_read_u8(&self, offset: u64) -> u8 {
-        assert!(offset < self.length);
-        unsafe { core::ptr::read_volatile((self.base + offset) as *const u8) }
+        self.io_read(offset)
     }
 
     /// Read a single word at given offset with a mechanism suitable for MMIO
     pub fn io_read_u16(&self, offset: u64) -> u16 {
-        assert!(offset + 1 < self.length);
-        unsafe { core::ptr::read_volatile((self.base + offset) as *const u16) }
+        self.io_read(offset)
     }
 
     /// Read a single dword at given offset with a mechanism suitable for MMIO
     pub fn io_read_u32(&self, offset: u64) -> u32 {
-        assert!(offset + 3 < self.length);
-        unsafe { core::ptr::read_volatile((self.base + offset) as *const u32) }
+        self.io_read(offset)
     }
 
     /// Read a single qword at given offset with a mechanism suitable for MMIO
     pub fn io_read_u64(&self, offset: u64) -> u64 {
-        assert!(offset + 7 < self.length);
-        unsafe { core::ptr::read_volatile((self.base + offset) as *const u64) }
+        self.io_read(offset)
+    }
+
+    /// Write a value at given offset using a mechanism suitable for MMIO
+    fn io_write<T>(&self, offset: u64, value: T) {
+        assert!((offset + (core::mem::size_of::<T>() - 1) as u64) < self.length);
+        unsafe {
+            core::ptr::write_volatile((self.base + offset) as *mut T, value);
+        }
     }
 
     /// Write a single byte at given offset with a mechanism suitable for MMIO
     pub fn io_write_u8(&self, offset: u64, value: u8) {
-        assert!(offset < self.length);
-        unsafe {
-            core::ptr::write_volatile((self.base + offset) as *mut u8, value);
-        }
+        self.io_write(offset, value)
     }
 
     /// Write a single word at given offset with a mechanism suitable for MMIO
     pub fn io_write_u16(&self, offset: u64, value: u16) {
-        assert!(offset + 1 < self.length);
-        unsafe {
-            core::ptr::write_volatile((self.base + offset) as *mut u16, value);
-        }
+        self.io_write(offset, value)
     }
 
     /// Write a single dword at given offset with a mechanism suitable for MMIO
     pub fn io_write_u32(&self, offset: u64, value: u32) {
-        assert!(offset + 3 < self.length);
-        unsafe {
-            core::ptr::write_volatile((self.base + offset) as *mut u32, value);
-        }
+        self.io_write(offset, value)
     }
 
     /// Write a single qword at given offset with a mechanism suitable for MMIO
     pub fn io_write_u64(&self, offset: u64, value: u64) {
-        assert!(offset + 7 < self.length);
-        unsafe {
-            core::ptr::write_volatile((self.base + offset) as *mut u64, value);
-        }
+        self.io_write(offset, value)
     }
 }


### PR DESCRIPTION
Sure, why not?

I resisted the urge to change all of the offsets from `u64` to `usize`, which is the natural pointer size of the target, but in my experience on embedded platforms, that's the more idiomatic type to use.