### PR TITLE
build: Target specific nightly Rust version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ dist: xenial
 language: rust
 
 rust:
-  - nightly
+  - nightly-2019-05-10
 
 before_script:
   - rustup component add clippy

--- a/rust-toolchain
+++ b/rust-toolchain
@@ -1,1 +1,1 @@
-nightly
+nightly-2019-05-10


### PR DESCRIPTION
Current nightly is failing with the CI due to lack of clippy so fix on
the 2019-05-10 version.

Signed-off-by: Rob Bradford <robert.bradford@intel.com>