### PR TITLE
Linker: Change to rust-lld for linking

### DIFF
--- a/layout.ld
+++ b/layout.ld
@@ -4,27 +4,27 @@ SECTIONS
 {
 	. = 1M;
 	start_of_text = . ;
-	.text BLOCK(4K) : ALIGN(4K)
+	.text : ALIGN(4K)
 	{
-		*(.text)
+		*(.text .text.*)
 	}
 	end_of_text = . ;
 
 	start_of_data = . ;
-	.rodata BLOCK(4K) : ALIGN(4K)
+	.rodata : ALIGN(4K)
 	{
-		*(.rodata)
+		*(.rodata .rodata.*)
 	}
  
-	.data BLOCK(4K) : ALIGN(4K)
+	.data : ALIGN(4K)
 	{
-		*(.data)
+		*(.data .data.*)
 	}
 	end_of_data = . ;
  
-	.bss BLOCK(4K) : ALIGN(4K)
+	.bss : ALIGN(4K)
 	{
 		*(COMMON)
-		*(.bss)
+		*(.bss .bss.*)
 	}
 }

--- a/target.json
+++ b/target.json
@@ -7,16 +7,14 @@
   "target-c-int-width": "32",
   "os": "none",
   "executables": true,
-  "linker": "gcc",
-  "linker-flavor": "gcc",
+  "linker": "rust-lld",
+  "linker-flavor": "ld.lld",
   "panic-strategy": "abort",
   "disable-redzone": true,
   "features": "-mmx,-sse,+soft-float",
   "pre-link-args": {
-	  "gcc": [
-		  "-Wl,--script=layout.ld",
-		  "-Wl,--nmagic",
-		  "-nostartfiles"
-	  ]
+    "ld.lld": [
+      "--script=layout.ld"
+    ]
   }
 }


### PR DESCRIPTION
When building for a custom or bare metal platform, it is often be more
useful to use the LLVM linker shipped with Rust (`rust-lld`). As Rust is
heavily integrated with LLVM, using LLVM's linker can result in smaller
and simpler binaries.

This change does two things,
  - Changes the linker script (`layout.ld`) to:
     - Correctly combine sections together
     - Remove `BLOCK` as it does the same thing as `ALIGN`. See:
       https://access.redhat.com/documentation/en-US/Red_Hat_Enterprise_Linux/4/html/Using_ld_the_GNU_Linker/expressions.html
  - Changes `target.json` to use `rust-lld`

The results:
  - The debug build now works!!
  - The release binary is now smaller and simpler
    - Size shrinks from 116 KB to 70 KB
    - Stripped size shinks from 89 KB to 49 KB
    - Number of sections shinks from 333 to 10
    - Program headers shrink from 7 to 4
    - The unnecessary dynamic section, relocation section,
      and `.dynsym` section are now gone.
    - Symbol table entries shrink from 540 to 220
  - We can now (potentially) use LTO

Testing:
  - Ran with Firecracker using instructions in `README.md`
    - All builds (before and after this change) kernel panic as
      expected, due to the virtio block device reset issue.
  - Ran with `cloud-hypervisor`; everything boots/works normally.

Signed-off-by: Joe Richey <joerichey@google.com>