### PR TITLE
fat: Fix directory handling that spans multiple clusters

### DIFF
--- a/src/fat.rs
+++ b/src/fat.rs
@@ -158,7 +158,7 @@ impl<'a> Directory<'a> {
         let mut long_entry = [0u16; 260];
         loop {
             let sector = if self.cluster.is_some() {
-                if self.sector > self.filesystem.sectors_per_cluster {
+                if self.sector >= self.filesystem.sectors_per_cluster {
                     match self.filesystem.next_cluster(self.cluster.unwrap()) {
                         Ok(new_cluster) => {
                             self.cluster = Some(new_cluster);


### PR DESCRIPTION
Locate the next cluster when sector within the cluster (self.sector) is
greater than or equal to the number of sectors in the cluster. This is
needed as the sector is zero indexed and the increment happens on a
previous loop around.

Signed-off-by: Rob Bradford <robert.bradford@intel.com>