### PR TITLE
Expose ACPI tables via EFI

### DIFF
--- a/src/efi/mod.rs
+++ b/src/efi/mod.rs
@@ -143,7 +143,7 @@ pub extern "win64" fn get_next_high_mono_count(_: *mut u32) -> Status {
 
 #[cfg(not(test))]
 pub extern "win64" fn reset_system(_: ResetType, _: Status, _: usize, _: *mut c_void) {
-    crate::i8042_reset();
+    // Don't do anything to force the kernel to use ACPI for shutdown and triple-fault for reset
 }
 
 #[cfg(not(test))]

--- a/src/efi/mod.rs
+++ b/src/efi/mod.rs
@@ -786,17 +786,32 @@ pub fn efi_exec(
     };
 
     let vendor_data = 0u32;
+    let acpi_rsdp_ptr = unsafe { *((ZERO_PAGE_START + 0x70) as u64 as *const u64) };
 
-    let mut ct = efi::ConfigurationTable {
-        vendor_guid: Guid::from_fields(
-            0x678a_9665,
-            0x9957,
-            0x4e7c,
-            0xa6,
-            0x27,
-            &[0x34, 0xc9, 0x46, 0x3d, 0xd2, 0xac],
-        ),
-        vendor_table: &vendor_data as *const _ as *mut _,
+    let mut ct = if acpi_rsdp_ptr != 0 {
+        efi::ConfigurationTable {
+            vendor_guid: Guid::from_fields(
+                0x8868_e871,
+                0xe4f1,
+                0x11d3,
+                0xbc,
+                0x22,
+                &[0x00, 0x80, 0xc7, 0x3c, 0x88, 0x81],
+            ),
+            vendor_table: acpi_rsdp_ptr as u64 as *mut _,
+        }
+    } else {
+        efi::ConfigurationTable {
+            vendor_guid: Guid::from_fields(
+                0x678a_9665,
+                0x9957,
+                0x4e7c,
+                0xa6,
+                0x27,
+                &[0x34, 0xc9, 0x46, 0x3d, 0xd2, 0xac],
+            ),
+            vendor_table: &vendor_data as *const _ as *mut _,
+        }
     };
 
     let mut st = efi::SystemTable {


### PR DESCRIPTION
To allow EFI booted systems to shutdown and reboot.