### PR TITLE
build: improve linker script and target settings

### DIFF
--- a/.cargo/config
+++ b/.cargo/config
@@ -1,2 +1,0 @@
-[target.target]
-rustflags = ["-C", "link-arg=-s"]

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,7 @@ install:
 
 script:
   - cargo xbuild --release --target target.json
-  - cargo xclippy
+  - cargo xclippy --target target.json
   - cargo clippy --all-targets --all-features
   - cargo fmt --all -- --check
   - cargo test

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,14 +4,14 @@ version = "0.1.0"
 authors = ["Rob Bradford <robert.bradford@intel.com>"]
 edition = "2018"
 
-# the profile used for `cargo build`
+# Despite "panic-strategy": "abort" being set in target.json, panic = "abort" is
+# needed here to make "cargo check" and "cargo clippy" run without errors.
 [profile.dev]
-panic = "abort" # disable stack unwinding on panic
+panic = "abort"
 lto = true
 
-# the profile used for `cargo build --release`
 [profile.release]
-panic = "abort" # disable stack unwinding on panic
+panic = "abort"
 lto = true
 
 [dependencies]

--- a/layout.ld
+++ b/layout.ld
@@ -15,10 +15,9 @@ SECTIONS
 	/* Mapping in the program headers makes it easier to mmap the whole file. */
 	. += SIZEOF_HEADERS ;
 
-	.rodata : { *(.rodata .rodata.*) } :rodata
-	.data   : { *(.data .data.*)     } :data
-	.bss    : { *(.bss .bss.*)       } :data
-	.text   : { *(.text .text.*)     } :text
+	.rodata : { *(.rodata .rodata.*)            } :rodata
+	.data   : { *(.data .data.*) *(.bss .bss.*) } :data
+	.text   : { *(.text .text.*)                } :text
 
 	_end_of_file = . ;
 

--- a/target.json
+++ b/target.json
@@ -12,6 +12,9 @@
   "panic-strategy": "abort",
   "disable-redzone": true,
   "features": "-mmx,-sse,+soft-float",
+  "dynamic-linking-available": false,
+  "code-model": "small",
+  "relocation-model": "static",
   "pre-link-args": {
     "ld.lld": [
       "-s",

--- a/target.json
+++ b/target.json
@@ -14,6 +14,7 @@
   "features": "-mmx,-sse,+soft-float",
   "pre-link-args": {
     "ld.lld": [
+      "-s",
       "--script=layout.ld"
     ]
   }


### PR DESCRIPTION
This change is a few small fixes to `target.json` and `layout.ld`

- Set stripping in `layout.ld`
  - Fixes my mistake from #20 
  - We already set linking flags in `layout.ld`, we shouldn't also be setting them in a second place.
  - I updated the comments to explain why we can also do this for `panic = "abort"`
    - Without setting the default target to be `target.json`, `cargo check` and `cargo clippy` will break when building for the host target.
- Merge `.bss` into `.data`
  - This [`.bss` section](https://en.wikipedia.org/wiki/.bss) normally represents "uninitialized/zero" data that will later be written by the program. Generally this means it has a runtime memory area, but no corresponding data in the output binary. The program header just says where to load it.
  - To make the loader's job easier (including the custom loader we will need for #5), we put the `.bss` section in `.data`. This now puts explicitly zeroed data in `.data` instead of relying on the loader to "expand" the `.bss` data at runtime.
  - EDK2 [uses a similar trick](https://github.com/tianocore/edk2/blob/3a63c17ebc853cbb27d190729d01e27f68e65b94/BaseTools/Scripts/GccBase.lds#L47)
  - This doesn't _currently_ have an effect on binary size, as `ld.ldd` (unlike the gnutools `ld`) just directly zeros the `.bss` region in the file. However, this isn't a stable behavior to rely on.
- Set more parameters in `target.json`
  - As we're building a firmware, we have no need for Rust's (on by default) [Position Independent Code (PIC)](https://en.wikipedia.org/wiki/Position-independent_code). This is controlled by the `relocation-mode` option.
  - We also explicitly set `code-model` and `dynamic-linking-available` to make our linking assumptions clear.
   - This makes the binary a little smaller and a little faster, but the main reason to do this is to making linking simpler.

Signed-off-by: Joe Richey <joerichey@google.com>