### PR TITLE
Remove `lazy_static` dependancy

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,16 +10,7 @@ name = "hypervisor-fw"
 version = "0.1.0"
 dependencies = [
  "cpuio 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "r-efi 2.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "spin 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "lazy_static"
-version = "1.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
  "spin 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -35,6 +26,5 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [metadata]
 "checksum cpuio 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "22b8e308ccfc5acf3b82f79c0eac444cf6114cb2ac67a230ca6c177210068daa"
-"checksum lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "bc5729f27f159ddd61f4df6228e827e86643d4d3e7c32183cb30a1c08f604a14"
 "checksum r-efi 2.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "8f2c7f9e57367053a4c9d2f235e715b7a4fa8b774b78eb3e477b2345dc2bb33d"
 "checksum spin 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)" = "44363f6f51401c34e7be73db0db371c04705d35efbe9f7d6082e03a921a32c55"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12,7 +12,7 @@ dependencies = [
  "cpuio 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "r-efi 2.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "spin 0.4.10 (registry+https://github.com/rust-lang/crates.io-index)",
+ "spin 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -30,11 +30,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "spin"
-version = "0.4.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-
-[[package]]
-name = "spin"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
@@ -42,5 +37,4 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum cpuio 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "22b8e308ccfc5acf3b82f79c0eac444cf6114cb2ac67a230ca6c177210068daa"
 "checksum lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "bc5729f27f159ddd61f4df6228e827e86643d4d3e7c32183cb30a1c08f604a14"
 "checksum r-efi 2.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "8f2c7f9e57367053a4c9d2f235e715b7a4fa8b774b78eb3e477b2345dc2bb33d"
-"checksum spin 0.4.10 (registry+https://github.com/rust-lang/crates.io-index)" = "ceac490aa12c567115b40b7b7fceca03a6c9d53d5defea066123debc83c5dc1f"
 "checksum spin 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)" = "44363f6f51401c34e7be73db0db371c04705d35efbe9f7d6082e03a921a32c55"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ log-panic = ["log-serial"]
 
 [dependencies]
 cpuio = "*"
-spin = "0.4.9"
+spin = "0.5"
 r-efi = "2.1.0"
 
 [dependencies.lazy_static]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,15 @@ lto = true
 panic = "abort"
 lto = true
 
+[features]
+default = ["log-serial", "log-panic"]
+# Have the log! macro write to serial output. Disabling this significantly
+# reduces code size, but makes debugging essentially impossible
+log-serial = []
+# Log panics to serial output. Disabling this (without disabling log-serial)
+# gets you most of the code size reduction, without losing _all_ debugging.
+log-panic = ["log-serial"]
+
 [dependencies]
 cpuio = "*"
 spin = "0.4.9"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,3 @@ cpuio = "*"
 spin = "0.5"
 r-efi = "2.1.0"
 
-[dependencies.lazy_static]
-version = "1.0"
-features = ["spin_no_std"]
-

--- a/layout.ld
+++ b/layout.ld
@@ -32,11 +32,11 @@ SECTIONS
 
 	firmware_ram_size = . - ram_min;
 
-	/* Memory for 64 GiB identity mapping, keep synced with ADDRESS_SPACE_GIB */
-	identity_mapped_gbs = 64;
+	/* Memory for identity mapping, keep synced with ADDRESS_SPACE_GIB */
+	address_space_gib = 4;
 	. = ALIGN(4K);
 	pml2t = .;
-	. += 4K * identity_mapped_gbs;
+	. += 4K * address_space_gib;
 
 	ASSERT((. <= ram_max - stack_size), "firmware size too big for RAM region")
 

--- a/layout.ld
+++ b/layout.ld
@@ -1,4 +1,4 @@
-ENTRY(_start)
+ENTRY(ram64_start)
 
 PHDRS
 {
@@ -25,7 +25,10 @@ SECTIONS
 
 	.rodata : { *(.rodata .rodata.*)            } :rodata
 	.data   : { *(.data .data.*) *(.bss .bss.*) } :data
-	.text   : { *(.text .text.*)                } :text
+	.text   : {
+		*(.text .text.*)
+		*(.ram64)
+	} :text
 
 	firmware_ram_size = . - ram_min;
 

--- a/layout.ld
+++ b/layout.ld
@@ -7,19 +7,35 @@ PHDRS
   text   PT_LOAD               ;
 }
 
+/* Loaders like to put stuff in low memory (< 1M), so we don't use it. */
+ram_min = 1M;
+ram_max = 2M;
+/* Our stack grows down from ram_max. TODO: Add a guard for stack overflows. */
+stack_size = 64K;
+
+/* Pagetable locations loaded by Firecracker/cloud-hypervisor */
+pml4t = 0x9000;
+pml3t = 0xa000;
+
 SECTIONS
 {
-	. = 1M ;
-	_start_of_file = . ;
-
 	/* Mapping in the program headers makes it easier to mmap the whole file. */
-	. += SIZEOF_HEADERS ;
+	. = ram_min;
+	. += SIZEOF_HEADERS;
 
 	.rodata : { *(.rodata .rodata.*)            } :rodata
 	.data   : { *(.data .data.*) *(.bss .bss.*) } :data
 	.text   : { *(.text .text.*)                } :text
 
-	_end_of_file = . ;
+	firmware_ram_size = . - ram_min;
+
+	/* Memory for 64 GiB identity mapping, keep synced with ADDRESS_SPACE_GIB */
+	identity_mapped_gbs = 64;
+	. = ALIGN(4K);
+	pml2t = .;
+	. += 4K * identity_mapped_gbs;
+
+	ASSERT((. <= ram_max - stack_size), "firmware size too big for RAM region")
 
 	/* Match edk2's GccBase.lds DISCARD section */
 	/DISCARD/ : {

--- a/src/asm/ram64.s
+++ b/src/asm/ram64.s
@@ -1,0 +1,29 @@
+.section .ram64, "ax"
+.global ram64_start
+.code64
+
+ram64_start:
+    # Indicate (via serial) that we are in long/64-bit mode
+    movw $0x3f8, %dx
+    movb $'L', %al
+    outb %al, %dx
+
+    # Enable SSE2 for XMM registers (needed for EFI calling)
+    # Clear CR0.EM and Set CR0.MP
+    movq %cr0, %rax
+    andb $0b11111011, %al # Clear bit 2
+    orb  $0b00000010, %al # Set bit 1
+    movq %rax, %cr0
+    # Set CR4.OSFXSR and CR4.OSXMMEXCPT
+    movq %cr4, %rax
+    orb  $0b00000110, %ah # Set bits 9 and 10
+    movq %rax, %cr4
+
+    # Setup the stack (at the end of our RAM region)
+    movq $ram_max, %rsp
+
+    jmp rust64_start
+
+halt_loop:
+    hlt
+    jmp halt_loop

--- a/src/block.rs
+++ b/src/block.rs
@@ -14,18 +14,14 @@
 
 use core::cell::RefCell;
 
-#[cfg(not(test))]
 use crate::virtio::Error as VirtioError;
-#[cfg(not(test))]
 use crate::virtio::VirtioTransport;
 
-#[cfg(not(test))]
 const QUEUE_SIZE: usize = 16;
 
 #[repr(C)]
 #[repr(align(16))]
 #[derive(Default)]
-#[cfg(not(test))]
 /// A virtio qeueue entry descriptor
 struct Desc {
     addr: u64,
@@ -37,7 +33,6 @@ struct Desc {
 #[repr(C)]
 #[repr(align(2))]
 #[derive(Default)]
-#[cfg(not(test))]
 /// The virtio available ring
 struct AvailRing {
     flags: u16,
@@ -48,7 +43,6 @@ struct AvailRing {
 #[repr(C)]
 #[repr(align(4))]
 #[derive(Default)]
-#[cfg(not(test))]
 /// The virtio used ring
 struct UsedRing {
     flags: u16,
@@ -58,7 +52,6 @@ struct UsedRing {
 
 #[repr(C)]
 #[derive(Default)]
-#[cfg(not(test))]
 /// A single element in the used ring
 struct UsedElem {
     id: u32,
@@ -67,7 +60,6 @@ struct UsedElem {
 
 #[repr(C)]
 #[repr(align(64))]
-#[cfg(not(test))]
 /// Device driver for virtio block over any transport
 pub struct VirtioBlockDevice<'a> {
     transport: &'a mut dyn VirtioTransport,
@@ -77,7 +69,6 @@ pub struct VirtioBlockDevice<'a> {
 #[repr(C)]
 #[repr(align(64))]
 #[derive(Default)]
-#[cfg(not(test))]
 struct DriverState {
     descriptors: [Desc; QUEUE_SIZE],
     avail: AvailRing,
@@ -88,12 +79,10 @@ struct DriverState {
 pub enum Error {
     BlockIOError,
 
-    #[cfg(not(test))]
     BlockNotSupported,
 }
 
 #[repr(C)]
-#[cfg(not(test))]
 /// Header used for virtio block requests
 struct BlockRequestHeader {
     request: u32,
@@ -102,7 +91,6 @@ struct BlockRequestHeader {
 }
 
 #[repr(C)]
-#[cfg(not(test))]
 /// Footer used for virtio block requests
 struct BlockRequestFooter {
     status: u8,
@@ -121,7 +109,6 @@ pub trait SectorWrite {
     fn flush(&self) -> Result<(), Error>;
 }
 
-#[cfg(not(test))]
 #[derive(PartialEq, Copy, Clone)]
 enum RequestType {
     Read = 0,
@@ -129,7 +116,6 @@ enum RequestType {
     Flush = 4,
 }
 
-#[cfg(not(test))]
 impl<'a> VirtioBlockDevice<'a> {
     pub fn new(transport: &'a mut dyn VirtioTransport) -> VirtioBlockDevice<'a> {
         VirtioBlockDevice {
@@ -307,14 +293,12 @@ impl<'a> VirtioBlockDevice<'a> {
     }
 }
 
-#[cfg(not(test))]
 impl<'a> SectorRead for VirtioBlockDevice<'a> {
     fn read(&self, sector: u64, data: &mut [u8]) -> Result<(), Error> {
         self.request(sector, Some(data), RequestType::Read)
     }
 }
 
-#[cfg(not(test))]
 impl<'a> SectorWrite for VirtioBlockDevice<'a> {
     fn write(&self, sector: u64, data: &mut [u8]) -> Result<(), Error> {
         self.request(sector, Some(data), RequestType::Write)

--- a/src/bzimage.rs
+++ b/src/bzimage.rs
@@ -15,7 +15,6 @@
 use crate::fat;
 use fat::Read;
 
-#[cfg(not(test))]
 pub enum Error {
     FileError,
     KernelOld,
@@ -23,7 +22,6 @@ pub enum Error {
     NotRelocatable,
 }
 
-#[cfg(not(test))]
 impl From<fat::Error> for Error {
     fn from(_: fat::Error) -> Error {
         Error::FileError
@@ -31,23 +29,17 @@ impl From<fat::Error> for Error {
 }
 
 // From firecracker
-#[cfg(not(test))]
 /// Kernel command line start address.
 const CMDLINE_START: usize = 0x4b000;
-#[cfg(not(test))]
 /// Kernel command line start address maximum size.
 const CMDLINE_MAX_SIZE: usize = 0x10000;
-#[cfg(not(test))]
 /// The 'zero page', a.k.a linux kernel bootparams.
 pub const ZERO_PAGE_START: usize = 0x7000;
 
-#[cfg(not(test))]
 const KERNEL_LOCATION: u32 = 0x20_0000;
 
-#[cfg(not(test))]
 const E820_RAM: u32 = 1;
 
-#[cfg(not(test))]
 #[repr(C, packed)]
 struct E820Entry {
     addr: u64,
@@ -55,7 +47,6 @@ struct E820Entry {
     entry_type: u32,
 }
 
-#[cfg(not(test))]
 pub fn load_initrd(f: &mut dyn Read) -> Result<(), Error> {
     let mut zero_page = crate::mem::MemoryRegion::new(ZERO_PAGE_START as u64, 4096);
 
@@ -119,7 +110,6 @@ pub fn load_initrd(f: &mut dyn Read) -> Result<(), Error> {
     Ok(())
 }
 
-#[cfg(not(test))]
 pub fn append_commandline(addition: &str) -> Result<(), Error> {
     let mut cmdline_region =
         crate::mem::MemoryRegion::new(CMDLINE_START as u64, CMDLINE_MAX_SIZE as u64);
@@ -146,7 +136,6 @@ pub fn append_commandline(addition: &str) -> Result<(), Error> {
     Ok(())
 }
 
-#[cfg(not(test))]
 pub fn load_kernel(f: &mut dyn Read) -> Result<u64, Error> {
     f.seek(0)?;
 

--- a/src/common.rs
+++ b/src/common.rs
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#[cfg(not(test))]
 #[macro_export]
 macro_rules! offset_of {
     ($container:ty, $field:ident) => {
@@ -20,7 +19,6 @@ macro_rules! offset_of {
     };
 }
 
-#[cfg(not(test))]
 #[macro_export]
 macro_rules! container_of {
     ($ptr:ident, $container:ty, $field:ident) => {{
@@ -28,7 +26,6 @@ macro_rules! container_of {
     }};
 }
 
-#[cfg(not(test))]
 #[macro_export]
 macro_rules! container_of_mut {
     ($ptr:ident, $container:ty, $field:ident) => {{
@@ -36,7 +33,6 @@ macro_rules! container_of_mut {
     }};
 }
 
-#[cfg(not(test))]
 pub fn ucs2_as_ascii_length(input: *const u16) -> usize {
     let mut len = 0;
     loop {
@@ -50,7 +46,6 @@ pub fn ucs2_as_ascii_length(input: *const u16) -> usize {
     len
 }
 
-#[cfg(not(test))]
 pub fn ucs2_to_ascii(input: *const u16, output: &mut [u8]) {
     let mut i: usize = 0;
     assert!(output.len() >= ucs2_as_ascii_length(input));
@@ -65,7 +60,6 @@ pub fn ucs2_to_ascii(input: *const u16, output: &mut [u8]) {
     }
 }
 
-#[cfg(not(test))]
 pub fn ascii_to_ucs2(input: &str, output: &mut [u16]) {
     assert!(output.len() >= input.len() * 2);
 

--- a/src/efi/alloc.rs
+++ b/src/efi/alloc.rs
@@ -349,7 +349,6 @@ impl Allocator {
         count
     }
 
-    #[cfg(not(test))]
     pub fn update_virtual_addresses(&mut self, descriptors: &[MemoryDescriptor]) -> Status {
         let mut i = 0;
 
@@ -374,7 +373,6 @@ impl Allocator {
         Status::SUCCESS
     }
 
-    #[cfg(not(test))]
     pub fn get_map_key(&self) -> usize {
         self.key
     }

--- a/src/efi/block.rs
+++ b/src/efi/block.rs
@@ -18,7 +18,6 @@ use r_efi::efi::{AllocateType, Guid, MemoryType, Status};
 use r_efi::protocols::device_path::Protocol as DevicePathProtocol;
 use r_efi::{eficall, eficall_abi};
 
-#[cfg(not(test))]
 pub const PROTOCOL_GUID: Guid = Guid::from_fields(
     0x964e_5b21,
     0x6459,
@@ -28,7 +27,6 @@ pub const PROTOCOL_GUID: Guid = Guid::from_fields(
     &[0x00, 0xa0, 0xc9, 0x69, 0x72, 0x3b],
 );
 
-#[cfg(not(test))]
 #[repr(packed)]
 pub struct HardDiskDevicePathProtocol {
     pub device_path: DevicePathProtocol,
@@ -40,14 +38,12 @@ pub struct HardDiskDevicePathProtocol {
     pub signature_type: u8,
 }
 
-#[cfg(not(test))]
 #[repr(packed)]
 pub struct ControllerDevicePathProtocol {
     pub device_path: DevicePathProtocol,
     pub controller: u32,
 }
 
-#[cfg(not(test))]
 #[repr(C)]
 struct BlockIoMedia {
     media_id: u32,
@@ -61,7 +57,6 @@ struct BlockIoMedia {
     last_block: u64,
 }
 
-#[cfg(not(test))]
 #[repr(C)]
 pub struct BlockIoProtocol {
     revision: u64,
@@ -89,7 +84,6 @@ pub struct BlockIoProtocol {
     ) -> Status},
 }
 
-#[cfg(not(test))]
 #[repr(C)]
 pub struct BlockWrapper<'a> {
     hw: super::HandleWrapper,
@@ -103,18 +97,15 @@ pub struct BlockWrapper<'a> {
     start_lba: u64,
 }
 
-#[cfg(not(test))]
 pub struct BlockWrappers<'a> {
     pub wrappers: [*mut BlockWrapper<'a>; 16],
     pub count: usize,
 }
 
-#[cfg(not(test))]
 pub extern "win64" fn reset(_: *mut BlockIoProtocol, _: bool) -> Status {
     Status::UNSUPPORTED
 }
 
-#[cfg(not(test))]
 pub extern "win64" fn read_blocks(
     proto: *mut BlockIoProtocol,
     _: u32,
@@ -143,7 +134,6 @@ pub extern "win64" fn read_blocks(
     Status::SUCCESS
 }
 
-#[cfg(not(test))]
 pub extern "win64" fn write_blocks(
     proto: *mut BlockIoProtocol,
     _: u32,
@@ -172,7 +162,6 @@ pub extern "win64" fn write_blocks(
     Status::SUCCESS
 }
 
-#[cfg(not(test))]
 pub extern "win64" fn flush_blocks(proto: *mut BlockIoProtocol) -> Status {
     let wrapper = container_of!(proto, BlockWrapper, proto);
     let wrapper = unsafe { &*wrapper };
@@ -184,7 +173,6 @@ pub extern "win64" fn flush_blocks(proto: *mut BlockIoProtocol) -> Status {
     }
 }
 
-#[cfg(not(test))]
 impl<'a> BlockWrapper<'a> {
     pub fn new(
         block: *const crate::block::VirtioBlockDevice,
@@ -307,7 +295,6 @@ impl<'a> BlockWrapper<'a> {
     }
 }
 
-#[cfg(not(test))]
 #[allow(clippy::transmute_ptr_to_ptr)]
 pub fn populate_block_wrappers(
     wrappers: &mut BlockWrappers,

--- a/src/efi/console.rs
+++ b/src/efi/console.rs
@@ -49,6 +49,8 @@ pub extern "win64" fn stdout_output_string(
     _: *mut SimpleTextOutputProtocol,
     message: *mut Char16,
 ) -> Status {
+    use core::fmt::Write;
+    let mut logger = crate::logger::LOGGER.lock();
     let mut string_end = false;
 
     loop {
@@ -62,7 +64,8 @@ pub extern "win64" fn stdout_output_string(
             }
             i += 1;
         }
-        crate::log!("{}", unsafe { core::str::from_utf8_unchecked(&output) });
+        let s = unsafe { core::str::from_utf8_unchecked(&output) };
+        logger.write_str(s).unwrap();
         if string_end {
             break;
         }

--- a/src/efi/console.rs
+++ b/src/efi/console.rs
@@ -18,28 +18,22 @@ use r_efi::protocols::simple_text_input::Protocol as SimpleTextInputProtocol;
 use r_efi::protocols::simple_text_output::Mode as SimpleTextOutputMode;
 use r_efi::protocols::simple_text_output::Protocol as SimpleTextOutputProtocol;
 
-#[cfg(not(test))]
 use super::{HandleType, HandleWrapper};
 
-#[cfg(not(test))]
 pub const STDIN_HANDLE: Handle = &HandleWrapper {
     handle_type: HandleType::None,
 } as *const _ as Handle;
-#[cfg(not(test))]
 pub const STDOUT_HANDLE: Handle = &HandleWrapper {
     handle_type: HandleType::None,
 } as *const _ as Handle;
-#[cfg(not(test))]
 pub const STDERR_HANDLE: Handle = &HandleWrapper {
     handle_type: HandleType::None,
 } as *const _ as Handle;
 
-#[cfg(not(test))]
 pub extern "win64" fn stdin_reset(_: *mut SimpleTextInputProtocol, _: Boolean) -> Status {
     Status::UNSUPPORTED
 }
 
-#[cfg(not(test))]
 pub extern "win64" fn stdin_read_key_stroke(
     _: *mut SimpleTextInputProtocol,
     _: *mut InputKey,
@@ -47,12 +41,10 @@ pub extern "win64" fn stdin_read_key_stroke(
     Status::NOT_READY
 }
 
-#[cfg(not(test))]
 pub extern "win64" fn stdout_reset(_: *mut SimpleTextOutputProtocol, _: Boolean) -> Status {
     Status::SUCCESS
 }
 
-#[cfg(not(test))]
 pub extern "win64" fn stdout_output_string(
     _: *mut SimpleTextOutputProtocol,
     message: *mut Char16,
@@ -78,7 +70,6 @@ pub extern "win64" fn stdout_output_string(
     Status::SUCCESS
 }
 
-#[cfg(not(test))]
 pub extern "win64" fn stdout_test_string(
     _: *mut SimpleTextOutputProtocol,
     _: *mut Char16,
@@ -86,7 +77,6 @@ pub extern "win64" fn stdout_test_string(
     Status::SUCCESS
 }
 
-#[cfg(not(test))]
 pub extern "win64" fn stdout_query_mode(
     _: *mut SimpleTextOutputProtocol,
     mode: usize,
@@ -104,7 +94,6 @@ pub extern "win64" fn stdout_query_mode(
     }
 }
 
-#[cfg(not(test))]
 pub extern "win64" fn stdout_set_mode(_: *mut SimpleTextOutputProtocol, mode: usize) -> Status {
     if mode == 0 {
         Status::SUCCESS
@@ -113,18 +102,15 @@ pub extern "win64" fn stdout_set_mode(_: *mut SimpleTextOutputProtocol, mode: us
     }
 }
 
-#[cfg(not(test))]
 pub extern "win64" fn stdout_set_attribute(_: *mut SimpleTextOutputProtocol, _: usize) -> Status {
     // Accept all attribute changes but ignore them
     Status::SUCCESS
 }
 
-#[cfg(not(test))]
 pub extern "win64" fn stdout_clear_screen(_: *mut SimpleTextOutputProtocol) -> Status {
     Status::UNSUPPORTED
 }
 
-#[cfg(not(test))]
 pub extern "win64" fn stdout_set_cursor_position(
     _: *mut SimpleTextOutputProtocol,
     _: usize,
@@ -133,19 +119,16 @@ pub extern "win64" fn stdout_set_cursor_position(
     Status::UNSUPPORTED
 }
 
-#[cfg(not(test))]
 pub extern "win64" fn stdout_enable_cursor(_: *mut SimpleTextOutputProtocol, _: Boolean) -> Status {
     Status::UNSUPPORTED
 }
 
-#[cfg(not(test))]
 pub const STDIN: SimpleTextInputProtocol = SimpleTextInputProtocol {
     reset: stdin_reset,
     read_key_stroke: stdin_read_key_stroke,
     wait_for_key: 0 as Event,
 };
 
-#[cfg(not(test))]
 pub const STDOUT_OUTPUT_MODE: SimpleTextOutputMode = SimpleTextOutputMode {
     max_mode: 1,
     mode: 0,
@@ -155,7 +138,6 @@ pub const STDOUT_OUTPUT_MODE: SimpleTextOutputMode = SimpleTextOutputMode {
     cursor_visible: Boolean::FALSE,
 };
 
-#[cfg(not(test))]
 pub const STDOUT: SimpleTextOutputProtocol = SimpleTextOutputProtocol {
     reset: stdout_reset,
     output_string: stdout_output_string,

--- a/src/efi/file.rs
+++ b/src/efi/file.rs
@@ -53,7 +53,7 @@ pub extern "win64" fn open(
     let wrapper = unsafe { &*wrapper };
 
     if !wrapper.root {
-        log!("Attempt to open file from non-root file is unsupported\n");
+        log!("Attempt to open file from non-root file is unsupported");
         return Status::UNSUPPORTED;
     }
 

--- a/src/efi/file.rs
+++ b/src/efi/file.rs
@@ -19,14 +19,12 @@ use r_efi::protocols::device_path::Protocol as DevicePathProtocol;
 use r_efi::protocols::file::Protocol as FileProtocol;
 use r_efi::protocols::simple_file_system::Protocol as SimpleFileSystemProtocol;
 
-#[cfg(not(test))]
 #[repr(C)]
 pub struct FileDevicePathProtocol {
     pub device_path: DevicePathProtocol,
     pub filename: [u16; 64],
 }
 
-#[cfg(not(test))]
 pub extern "win64" fn filesystem_open_volume(
     fs_proto: *mut SimpleFileSystemProtocol,
     file: *mut *mut FileProtocol,
@@ -44,7 +42,6 @@ pub extern "win64" fn filesystem_open_volume(
     }
 }
 
-#[cfg(not(test))]
 pub extern "win64" fn open(
     file_in: *mut FileProtocol,
     file_out: *mut *mut FileProtocol,
@@ -81,7 +78,6 @@ pub extern "win64" fn open(
     }
 }
 
-#[cfg(not(test))]
 pub extern "win64" fn close(proto: *mut FileProtocol) -> Status {
     let wrapper = container_of!(proto, FileWrapper, proto);
     super::ALLOCATOR
@@ -89,12 +85,10 @@ pub extern "win64" fn close(proto: *mut FileProtocol) -> Status {
         .free_pages(&wrapper as *const _ as u64)
 }
 
-#[cfg(not(test))]
 pub extern "win64" fn delete(_: *mut FileProtocol) -> Status {
     Status::UNSUPPORTED
 }
 
-#[cfg(not(test))]
 pub extern "win64" fn read(file: *mut FileProtocol, size: *mut usize, buf: *mut c_void) -> Status {
     let wrapper = container_of_mut!(file, FileWrapper, proto);
 
@@ -127,22 +121,18 @@ pub extern "win64" fn read(file: *mut FileProtocol, size: *mut usize, buf: *mut 
     }
 }
 
-#[cfg(not(test))]
 pub extern "win64" fn write(_: *mut FileProtocol, _: *mut usize, _: *mut c_void) -> Status {
     Status::UNSUPPORTED
 }
 
-#[cfg(not(test))]
 pub extern "win64" fn get_position(_: *mut FileProtocol, _: *mut u64) -> Status {
     Status::UNSUPPORTED
 }
 
-#[cfg(not(test))]
 pub extern "win64" fn set_position(_: *mut FileProtocol, _: u64) -> Status {
     Status::UNSUPPORTED
 }
 
-#[cfg(not(test))]
 struct FileInfo {
     size: u64,
     file_size: u64,
@@ -154,7 +144,6 @@ struct FileInfo {
     _file_name: [Char16; 256],
 }
 
-#[cfg(not(test))]
 pub extern "win64" fn get_info(
     file: *mut FileProtocol,
     guid: *mut Guid,
@@ -184,7 +173,6 @@ pub extern "win64" fn get_info(
     }
 }
 
-#[cfg(not(test))]
 pub extern "win64" fn set_info(
     _: *mut FileProtocol,
     _: *mut Guid,
@@ -194,12 +182,10 @@ pub extern "win64" fn set_info(
     Status::UNSUPPORTED
 }
 
-#[cfg(not(test))]
 pub extern "win64" fn flush(_: *mut FileProtocol) -> Status {
     Status::UNSUPPORTED
 }
 
-#[cfg(not(test))]
 struct FileWrapper<'a> {
     fs: &'a crate::fat::Filesystem<'a>,
     proto: FileProtocol,
@@ -208,7 +194,6 @@ struct FileWrapper<'a> {
     root: bool,
 }
 
-#[cfg(not(test))]
 #[repr(C)]
 pub struct FileSystemWrapper<'a> {
     hw: super::HandleWrapper,
@@ -217,7 +202,6 @@ pub struct FileSystemWrapper<'a> {
     pub block_part_id: Option<u32>,
 }
 
-#[cfg(not(test))]
 impl<'a> FileSystemWrapper<'a> {
     fn create_file(&self, root: bool) -> Option<*mut FileWrapper> {
         let size = core::mem::size_of::<FileWrapper>();

--- a/src/efi/mod.rs
+++ b/src/efi/mod.rs
@@ -34,7 +34,6 @@ use core::ffi::c_void;
 
 use alloc::Allocator;
 
-#[cfg(not(test))]
 #[derive(Copy, Clone, PartialEq)]
 enum HandleType {
     None,
@@ -43,7 +42,6 @@ enum HandleType {
     LoadedImage,
 }
 
-#[cfg(not(test))]
 #[repr(C)]
 #[derive(Copy, Clone)]
 struct HandleWrapper {
@@ -54,33 +52,27 @@ lazy_static! {
     pub static ref ALLOCATOR: Mutex<Allocator> = Mutex::new(Allocator::new());
 }
 
-#[cfg(not(test))]
 static mut BLOCK_WRAPPERS: block::BlockWrappers = block::BlockWrappers {
     wrappers: [core::ptr::null_mut(); 16],
     count: 0,
 };
 
-#[cfg(not(test))]
 pub extern "win64" fn get_time(_: *mut Time, _: *mut TimeCapabilities) -> Status {
     Status::DEVICE_ERROR
 }
 
-#[cfg(not(test))]
 pub extern "win64" fn set_time(_: *mut Time) -> Status {
     Status::DEVICE_ERROR
 }
 
-#[cfg(not(test))]
 pub extern "win64" fn get_wakeup_time(_: *mut Boolean, _: *mut Boolean, _: *mut Time) -> Status {
     Status::UNSUPPORTED
 }
 
-#[cfg(not(test))]
 pub extern "win64" fn set_wakeup_time(_: Boolean, _: *mut Time) -> Status {
     Status::UNSUPPORTED
 }
 
-#[cfg(not(test))]
 pub extern "win64" fn set_virtual_address_map(
     map_size: usize,
     descriptor_size: usize,
@@ -100,12 +92,10 @@ pub extern "win64" fn set_virtual_address_map(
     ALLOCATOR.lock().update_virtual_addresses(descriptors)
 }
 
-#[cfg(not(test))]
 pub extern "win64" fn convert_pointer(_: usize, _: *mut *mut c_void) -> Status {
     Status::UNSUPPORTED
 }
 
-#[cfg(not(test))]
 pub extern "win64" fn get_variable(
     _: *mut Char16,
     _: *mut Guid,
@@ -116,7 +106,6 @@ pub extern "win64" fn get_variable(
     Status::NOT_FOUND
 }
 
-#[cfg(not(test))]
 pub extern "win64" fn get_next_variable_name(
     _: *mut usize,
     _: *mut Char16,
@@ -125,7 +114,6 @@ pub extern "win64" fn get_next_variable_name(
     Status::NOT_FOUND
 }
 
-#[cfg(not(test))]
 pub extern "win64" fn set_variable(
     _: *mut Char16,
     _: *mut Guid,
@@ -136,17 +124,14 @@ pub extern "win64" fn set_variable(
     Status::UNSUPPORTED
 }
 
-#[cfg(not(test))]
 pub extern "win64" fn get_next_high_mono_count(_: *mut u32) -> Status {
     Status::DEVICE_ERROR
 }
 
-#[cfg(not(test))]
 pub extern "win64" fn reset_system(_: ResetType, _: Status, _: usize, _: *mut c_void) {
     // Don't do anything to force the kernel to use ACPI for shutdown and triple-fault for reset
 }
 
-#[cfg(not(test))]
 pub extern "win64" fn update_capsule(
     _: *mut *mut CapsuleHeader,
     _: usize,
@@ -155,7 +140,6 @@ pub extern "win64" fn update_capsule(
     Status::UNSUPPORTED
 }
 
-#[cfg(not(test))]
 pub extern "win64" fn query_capsule_capabilities(
     _: *mut *mut CapsuleHeader,
     _: usize,
@@ -165,7 +149,6 @@ pub extern "win64" fn query_capsule_capabilities(
     Status::UNSUPPORTED
 }
 
-#[cfg(not(test))]
 pub extern "win64" fn query_variable_info(
     _: u32,
     max_storage: *mut u64,
@@ -180,15 +163,12 @@ pub extern "win64" fn query_variable_info(
     Status::SUCCESS
 }
 
-#[cfg(not(test))]
 pub extern "win64" fn raise_tpl(_: Tpl) -> Tpl {
     0
 }
 
-#[cfg(not(test))]
 pub extern "win64" fn restore_tpl(_: Tpl) {}
 
-#[cfg(not(test))]
 pub extern "win64" fn allocate_pages(
     allocate_type: AllocateType,
     memory_type: MemoryType,
@@ -212,12 +192,10 @@ pub extern "win64" fn allocate_pages(
     status
 }
 
-#[cfg(not(test))]
 pub extern "win64" fn free_pages(address: PhysicalAddress, _: usize) -> Status {
     ALLOCATOR.lock().free_pages(address)
 }
 
-#[cfg(not(test))]
 pub extern "win64" fn get_memory_map(
     memory_map_size: *mut usize,
     out: *mut MemoryDescriptor,
@@ -248,7 +226,6 @@ pub extern "win64" fn get_memory_map(
     Status::SUCCESS
 }
 
-#[cfg(not(test))]
 pub extern "win64" fn allocate_pool(
     memory_type: MemoryType,
     size: usize,
@@ -270,12 +247,10 @@ pub extern "win64" fn allocate_pool(
     status
 }
 
-#[cfg(not(test))]
 pub extern "win64" fn free_pool(ptr: *mut c_void) -> Status {
     ALLOCATOR.lock().free_pages(ptr as u64)
 }
 
-#[cfg(not(test))]
 pub extern "win64" fn create_event(
     _: u32,
     _: Tpl,
@@ -286,32 +261,26 @@ pub extern "win64" fn create_event(
     Status::UNSUPPORTED
 }
 
-#[cfg(not(test))]
 pub extern "win64" fn set_timer(_: Event, _: TimerDelay, _: u64) -> Status {
     Status::UNSUPPORTED
 }
 
-#[cfg(not(test))]
 pub extern "win64" fn wait_for_event(_: usize, _: *mut Event, _: *mut usize) -> Status {
     Status::UNSUPPORTED
 }
 
-#[cfg(not(test))]
 pub extern "win64" fn signal_event(_: Event) -> Status {
     Status::UNSUPPORTED
 }
 
-#[cfg(not(test))]
 pub extern "win64" fn close_event(_: Event) -> Status {
     Status::UNSUPPORTED
 }
 
-#[cfg(not(test))]
 pub extern "win64" fn check_event(_: Event) -> Status {
     Status::UNSUPPORTED
 }
 
-#[cfg(not(test))]
 const SHIM_LOCK_PROTOCOL_GUID: Guid = Guid::from_fields(
     0x605d_ab50,
     0xe046,
@@ -321,7 +290,6 @@ const SHIM_LOCK_PROTOCOL_GUID: Guid = Guid::from_fields(
     &[0x3d, 0xd8, 0x10, 0xdd, 0x8b, 0x23],
 );
 
-#[cfg(not(test))]
 pub extern "win64" fn install_protocol_interface(
     _: *mut Handle,
     guid: *mut Guid,
@@ -335,7 +303,6 @@ pub extern "win64" fn install_protocol_interface(
     }
 }
 
-#[cfg(not(test))]
 pub extern "win64" fn reinstall_protocol_interface(
     _: Handle,
     _: *mut Guid,
@@ -345,7 +312,6 @@ pub extern "win64" fn reinstall_protocol_interface(
     Status::NOT_FOUND
 }
 
-#[cfg(not(test))]
 pub extern "win64" fn uninstall_protocol_interface(
     _: Handle,
     _: *mut Guid,
@@ -354,7 +320,6 @@ pub extern "win64" fn uninstall_protocol_interface(
     Status::NOT_FOUND
 }
 
-#[cfg(not(test))]
 pub extern "win64" fn handle_protocol(
     handle: Handle,
     guid: *mut Guid,
@@ -370,7 +335,6 @@ pub extern "win64" fn handle_protocol(
     )
 }
 
-#[cfg(not(test))]
 pub extern "win64" fn register_protocol_notify(
     _: *mut Guid,
     _: Event,
@@ -379,7 +343,6 @@ pub extern "win64" fn register_protocol_notify(
     Status::UNSUPPORTED
 }
 
-#[cfg(not(test))]
 pub extern "win64" fn locate_handle(
     _: LocateSearchType,
     guid: *mut Guid,
@@ -416,17 +379,14 @@ pub extern "win64" fn locate_handle(
     Status::UNSUPPORTED
 }
 
-#[cfg(not(test))]
 pub extern "win64" fn locate_device_path(_: *mut Guid, _: *mut *mut c_void) -> Status {
     Status::NOT_FOUND
 }
 
-#[cfg(not(test))]
 pub extern "win64" fn install_configuration_table(_: *mut Guid, _: *mut c_void) -> Status {
     Status::UNSUPPORTED
 }
 
-#[cfg(not(test))]
 pub extern "win64" fn load_image(
     _: Boolean,
     _: Handle,
@@ -438,42 +398,34 @@ pub extern "win64" fn load_image(
     Status::UNSUPPORTED
 }
 
-#[cfg(not(test))]
 pub extern "win64" fn start_image(_: Handle, _: *mut usize, _: *mut *mut Char16) -> Status {
     Status::UNSUPPORTED
 }
 
-#[cfg(not(test))]
 pub extern "win64" fn exit(_: Handle, _: Status, _: usize, _: *mut Char16) -> Status {
     Status::UNSUPPORTED
 }
 
-#[cfg(not(test))]
 pub extern "win64" fn unload_image(_: Handle) -> Status {
     Status::UNSUPPORTED
 }
 
-#[cfg(not(test))]
 pub extern "win64" fn exit_boot_services(_: Handle, _: usize) -> Status {
     Status::SUCCESS
 }
 
-#[cfg(not(test))]
 pub extern "win64" fn get_next_monotonic_count(_: *mut u64) -> Status {
     Status::DEVICE_ERROR
 }
 
-#[cfg(not(test))]
 pub extern "win64" fn stall(_: usize) -> Status {
     Status::UNSUPPORTED
 }
 
-#[cfg(not(test))]
 pub extern "win64" fn set_watchdog_timer(_: usize, _: u64, _: usize, _: *mut Char16) -> Status {
     Status::UNSUPPORTED
 }
 
-#[cfg(not(test))]
 pub extern "win64" fn connect_controller(
     _: Handle,
     _: *mut Handle,
@@ -483,12 +435,10 @@ pub extern "win64" fn connect_controller(
     Status::UNSUPPORTED
 }
 
-#[cfg(not(test))]
 pub extern "win64" fn disconnect_controller(_: Handle, _: Handle, _: Handle) -> Status {
     Status::UNSUPPORTED
 }
 
-#[cfg(not(test))]
 pub extern "win64" fn open_protocol(
     handle: Handle,
     guid: *mut Guid,
@@ -552,12 +502,10 @@ pub extern "win64" fn open_protocol(
     Status::UNSUPPORTED
 }
 
-#[cfg(not(test))]
 pub extern "win64" fn close_protocol(_: Handle, _: *mut Guid, _: Handle, _: Handle) -> Status {
     Status::UNSUPPORTED
 }
 
-#[cfg(not(test))]
 pub extern "win64" fn open_protocol_information(
     _: Handle,
     _: *mut Guid,
@@ -567,7 +515,6 @@ pub extern "win64" fn open_protocol_information(
     Status::UNSUPPORTED
 }
 
-#[cfg(not(test))]
 pub extern "win64" fn protocols_per_handle(
     _: Handle,
     _: *mut *mut *mut Guid,
@@ -576,7 +523,6 @@ pub extern "win64" fn protocols_per_handle(
     Status::UNSUPPORTED
 }
 
-#[cfg(not(test))]
 pub extern "win64" fn locate_handle_buffer(
     _: LocateSearchType,
     _: *mut Guid,
@@ -587,12 +533,10 @@ pub extern "win64" fn locate_handle_buffer(
     Status::UNSUPPORTED
 }
 
-#[cfg(not(test))]
 pub extern "win64" fn locate_protocol(_: *mut Guid, _: *mut c_void, _: *mut *mut c_void) -> Status {
     Status::UNSUPPORTED
 }
 
-#[cfg(not(test))]
 pub extern "win64" fn install_multiple_protocol_interfaces(
     _: *mut Handle,
     _: *mut c_void,
@@ -601,7 +545,6 @@ pub extern "win64" fn install_multiple_protocol_interfaces(
     Status::UNSUPPORTED
 }
 
-#[cfg(not(test))]
 pub extern "win64" fn uninstall_multiple_protocol_interfaces(
     _: *mut Handle,
     _: *mut c_void,
@@ -610,18 +553,14 @@ pub extern "win64" fn uninstall_multiple_protocol_interfaces(
     Status::UNSUPPORTED
 }
 
-#[cfg(not(test))]
 pub extern "win64" fn calculate_crc32(_: *mut c_void, _: usize, _: *mut u32) -> Status {
     Status::UNSUPPORTED
 }
 
-#[cfg(not(test))]
 pub extern "win64" fn copy_mem(_: *mut c_void, _: *mut c_void, _: usize) {}
 
-#[cfg(not(test))]
 pub extern "win64" fn set_mem(_: *mut c_void, _: usize, _: u8) {}
 
-#[cfg(not(test))]
 pub extern "win64" fn create_event_ex(
     _: u32,
     _: Tpl,
@@ -633,19 +572,15 @@ pub extern "win64" fn create_event_ex(
     Status::UNSUPPORTED
 }
 
-#[cfg(not(test))]
 extern "win64" fn image_unload(_: Handle) -> Status {
     efi::Status::UNSUPPORTED
 }
 
-#[cfg(not(test))]
 /// The 'zero page', a.k.a linux kernel bootparams.
 pub const ZERO_PAGE_START: usize = 0x7000;
 
-#[cfg(not(test))]
 const E820_RAM: u32 = 1;
 
-#[cfg(not(test))]
 #[repr(C, packed)]
 struct E820Entry {
     addr: u64,
@@ -653,10 +588,8 @@ struct E820Entry {
     entry_type: u32,
 }
 
-#[cfg(not(test))]
 const PAGE_SIZE: u64 = 4096;
 
-#[cfg(not(test))]
 // Populate allocator from E820, fixed ranges for the firmware and the loaded binary.
 fn populate_allocator(image_address: u64, image_size: u64) {
     let mut zero_page = crate::mem::MemoryRegion::new(ZERO_PAGE_START as u64, 4096);
@@ -692,14 +625,12 @@ fn populate_allocator(image_address: u64, image_size: u64) {
     );
 }
 
-#[cfg(not(test))]
 #[repr(C)]
 struct LoadedImageWrapper {
     hw: HandleWrapper,
     proto: LoadedImageProtocol,
 }
 
-#[cfg(not(test))]
 pub fn efi_exec(
     address: u64,
     loaded_address: u64,

--- a/src/efi/mod.rs
+++ b/src/efi/mod.rs
@@ -17,7 +17,6 @@ mod block;
 mod console;
 mod file;
 
-use lazy_static::lazy_static;
 use spin::Mutex;
 
 use r_efi::efi;
@@ -48,9 +47,7 @@ struct HandleWrapper {
     handle_type: HandleType,
 }
 
-lazy_static! {
-    pub static ref ALLOCATOR: Mutex<Allocator> = Mutex::new(Allocator::new());
-}
+pub static ALLOCATOR: Mutex<Allocator> = Mutex::new(Allocator::new());
 
 static mut BLOCK_WRAPPERS: block::BlockWrappers = block::BlockWrappers {
     wrappers: [core::ptr::null_mut(); 16],

--- a/src/loader.rs
+++ b/src/loader.rs
@@ -22,20 +22,17 @@ pub struct LoaderConfig {
     pub cmdline: [u8; 4096],
 }
 
-#[cfg(not(test))]
 pub enum Error {
     FileError,
     BzImageError,
 }
 
-#[cfg(not(test))]
 impl From<fat::Error> for Error {
     fn from(_: fat::Error) -> Error {
         Error::FileError
     }
 }
 
-#[cfg(not(test))]
 impl From<bzimage::Error> for Error {
     fn from(_: bzimage::Error) -> Error {
         Error::BzImageError
@@ -125,7 +122,6 @@ fn default_entry_path(fs: &fat::Filesystem) -> Result<[u8; 260], fat::Error> {
     Ok(entry_path)
 }
 
-#[cfg(not(test))]
 pub fn load_default_entry(fs: &fat::Filesystem) -> Result<u64, Error> {
     let default_entry_path = default_entry_path(&fs)?;
     let default_entry_path = ascii_strip(&default_entry_path);

--- a/src/logger.rs
+++ b/src/logger.rs
@@ -54,9 +54,9 @@ impl fmt::Write for Logger {
 macro_rules! log {
     ($($arg:tt)*) => {{
         use core::fmt::Write;
-        #[cfg(not(test))]
+        #[cfg(all(feature = "log-serial", not(test)))]
         writeln!(&mut crate::logger::LOGGER.lock(), $($arg)*).unwrap();
-        #[cfg(test)]
+        #[cfg(all(feature = "log-serial", test))]
         println!($($arg)*);
     }};
 }

--- a/src/logger.rs
+++ b/src/logger.rs
@@ -16,16 +16,13 @@
 // from Philipp Oppermann
 
 use core::fmt;
-use lazy_static::lazy_static;
 use spin::Mutex;
 
 use cpuio::Port;
 
-lazy_static! {
-    pub static ref LOGGER: Mutex<Logger> = Mutex::new(Logger {
-        port: unsafe { Port::new(0x3f8) }
-    });
-}
+pub static LOGGER: Mutex<Logger> = Mutex::new(Logger {
+    port: unsafe { Port::new(0x3f8) },
+});
 
 pub struct Logger {
     port: Port<u8>,

--- a/src/main.rs
+++ b/src/main.rs
@@ -68,7 +68,7 @@ fn setup_pagetables() {
         pde.io_write_u64(i * 8, (0xb000u64 + (0x1000u64 * i)) | 0x03);
     }
 
-    log!("Page tables setup\n");
+    log!("Page tables setup");
 }
 
 const VIRTIO_PCI_VENDOR_ID: u16 = 0x1af4;
@@ -77,11 +77,11 @@ const VIRTIO_PCI_BLOCK_DEVICE_ID: u16 = 0x1042;
 fn boot_from_device(device: &mut block::VirtioBlockDevice) -> bool {
     match device.init() {
         Err(_) => {
-            log!("Error configuring block device\n");
+            log!("Error configuring block device");
             return false;
         }
         Ok(_) => log!(
-            "Virtio block device configured. Capacity: {} sectors\n",
+            "Virtio block device configured. Capacity: {} sectors",
             device.get_capacity()
         ),
     }
@@ -90,20 +90,20 @@ fn boot_from_device(device: &mut block::VirtioBlockDevice) -> bool {
 
     match part::find_efi_partition(device) {
         Ok((start, end)) => {
-            log!("Found EFI partition\n");
+            log!("Found EFI partition");
             f = fat::Filesystem::new(device, start, end);
             if f.init().is_err() {
-                log!("Failed to create filesystem\n");
+                log!("Failed to create filesystem");
                 return false;
             }
         }
         Err(_) => {
-            log!("Failed to find EFI partition\n");
+            log!("Failed to find EFI partition");
             return false;
         }
     }
 
-    log!("Filesystem ready\n");
+    log!("Filesystem ready");
 
     let jump_address;
 
@@ -112,28 +112,28 @@ fn boot_from_device(device: &mut block::VirtioBlockDevice) -> bool {
             jump_address = addr;
         }
         Err(_) => {
-            log!("Error loading default entry. Using EFI boot.\n");
+            log!("Error loading default entry. Using EFI boot.");
             match f.open("/EFI/BOOT/BOOTX64 EFI") {
                 Ok(mut file) => {
-                    log!("Found bootloader (BOOTX64.EFI)\n");
+                    log!("Found bootloader (BOOTX64.EFI)");
                     let mut l = pe::Loader::new(&mut file);
                     match l.load(0x20_0000) {
                         Ok((a, size)) => {
-                            log!("Executable loaded\n");
+                            log!("Executable loaded");
                             efi::efi_exec(a, 0x20_0000, size, &f, device);
                             return true;
                         }
                         Err(e) => {
                             match e {
-                                pe::Error::FileError => log!("File error\n"),
-                                pe::Error::InvalidExecutable => log!("Invalid executable\n"),
+                                pe::Error::FileError => log!("File error"),
+                                pe::Error::InvalidExecutable => log!("Invalid executable"),
                             }
                             return false;
                         }
                     }
                 }
                 Err(_) => {
-                    log!("Failed to find bootloader\n");
+                    log!("Failed to find bootloader");
                     return false;
                 }
             }
@@ -142,7 +142,7 @@ fn boot_from_device(device: &mut block::VirtioBlockDevice) -> bool {
 
     device.reset();
 
-    log!("Jumping to kernel\n");
+    log!("Jumping to kernel");
 
     // Rely on x86 C calling convention where second argument is put into %rsi register
     let ptr = jump_address as *const ();
@@ -157,7 +157,7 @@ pub extern "C" fn _start() -> ! {
         asm!("movq $$0x180000, %rsp");
     }
 
-    log!("Starting..\n");
+    log!("Starting..");
 
     enable_sse2();
     setup_pagetables();

--- a/src/main.rs
+++ b/src/main.rs
@@ -65,14 +65,22 @@ fn enable_sse2() {
 /// Setup page tables to provide an identity mapping over the full 4GiB range
 fn setup_pagetables() {
     const ADDRESS_SPACE_GIB: u64 = 64;
-    let pte = mem::MemoryRegion::new(0xb000, 512 * ADDRESS_SPACE_GIB * 8);
+    type Page = [u64; 512];
+
+    extern "C" {
+        static pml3t: Page;
+        static pml2t: [Page; ADDRESS_SPACE_GIB as usize];
+    }
+
+    let pte = mem::MemoryRegion::from_slice(unsafe { &pml2t });
     for i in 0..(512 * ADDRESS_SPACE_GIB) {
         pte.io_write_u64(i * 8, (i << 21) + 0x83u64)
     }
 
-    let pde = mem::MemoryRegion::new(0xa000, 4096);
+    let pml2t_addr = unsafe { pml2t.as_ptr() } as usize as u64;
+    let pde = mem::MemoryRegion::from_slice(unsafe { &pml3t });
     for i in 0..ADDRESS_SPACE_GIB {
-        pde.io_write_u64(i * 8, (0xb000u64 + (0x1000u64 * i)) | 0x03);
+        pde.io_write_u64(i * 8, (pml2t_addr + (0x1000u64 * i)) | 0x03);
     }
 
     log!("Page tables setup");

--- a/src/main.rs
+++ b/src/main.rs
@@ -16,6 +16,7 @@
 #![cfg_attr(not(test), no_std)]
 #![cfg_attr(not(test), no_main)]
 #![cfg_attr(test, allow(unused_imports))]
+#![cfg_attr(test, allow(dead_code))]
 
 #[macro_use]
 mod logger;
@@ -37,14 +38,11 @@ mod pci;
 mod pe;
 mod virtio;
 
-#[cfg(not(test))]
-#[panic_handler]
-#[allow(clippy::empty_loop)]
+#[cfg_attr(not(test), panic_handler)]
 fn panic(_info: &PanicInfo) -> ! {
     loop {}
 }
 
-#[cfg(not(test))]
 /// Enable SSE2 for XMM registers (needed for EFI calling)
 fn enable_sse2() {
     unsafe {
@@ -57,7 +55,6 @@ fn enable_sse2() {
     }
 }
 
-#[cfg(not(test))]
 /// Setup page tables to provide an identity mapping over the full 4GiB range
 fn setup_pagetables() {
     const ADDRESS_SPACE_GIB: u64 = 64;
@@ -74,12 +71,9 @@ fn setup_pagetables() {
     log!("Page tables setup\n");
 }
 
-#[cfg(not(test))]
 const VIRTIO_PCI_VENDOR_ID: u16 = 0x1af4;
-#[cfg(not(test))]
 const VIRTIO_PCI_BLOCK_DEVICE_ID: u16 = 0x1042;
 
-#[cfg(not(test))]
 fn boot_from_device(device: &mut block::VirtioBlockDevice) -> bool {
     match device.init() {
         Err(_) => {
@@ -157,9 +151,7 @@ fn boot_from_device(device: &mut block::VirtioBlockDevice) -> bool {
     true
 }
 
-#[cfg(not(test))]
-#[allow(unused_attributes)]
-#[no_mangle]
+#[cfg_attr(not(test), no_mangle)]
 pub extern "C" fn _start() -> ! {
     unsafe {
         asm!("movq $$0x180000, %rsp");

--- a/src/main.rs
+++ b/src/main.rs
@@ -38,6 +38,7 @@ mod pci;
 mod pe;
 mod virtio;
 
+#[cfg(not(test))]
 global_asm!(include_str!("asm/ram64.s"));
 
 extern "C" {

--- a/src/main.rs
+++ b/src/main.rs
@@ -52,12 +52,12 @@ fn panic(info: &PanicInfo) -> ! {
 
 /// Setup page tables to provide an identity mapping over the full 4GiB range
 fn setup_pagetables() {
-    const ADDRESS_SPACE_GIB: u64 = 64;
-    type Page = [u64; 512];
+    const ADDRESS_SPACE_GIB: u64 = 4;
+    type PageTable = [u64; 512];
 
     extern "C" {
-        static pml3t: Page;
-        static pml2t: [Page; ADDRESS_SPACE_GIB as usize];
+        static pml3t: PageTable;
+        static pml2t: [PageTable; ADDRESS_SPACE_GIB as usize];
     }
 
     let pte = mem::MemoryRegion::from_slice(unsafe { &pml2t });

--- a/src/main.rs
+++ b/src/main.rs
@@ -38,9 +38,16 @@ mod pci;
 mod pe;
 mod virtio;
 
+fn halt() -> ! {
+    loop {
+        unsafe { asm!("hlt") };
+    }
+}
+
 #[cfg_attr(not(test), panic_handler)]
-fn panic(_info: &PanicInfo) -> ! {
-    loop {}
+fn panic(info: &PanicInfo) -> ! {
+    log!("PANIC: {}", info);
+    halt()
 }
 
 /// Enable SSE2 for XMM registers (needed for EFI calling)
@@ -179,10 +186,5 @@ pub extern "C" fn _start() -> ! {
     let mut device = block::VirtioBlockDevice::new(&mut mmio_transport);
     boot_from_device(&mut device);
 
-    #[allow(clippy::empty_loop)]
-    loop {
-        unsafe {
-            asm!("hlt");
-        }
-    }
+    halt()
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -15,8 +15,8 @@
 #![feature(global_asm)]
 #![cfg_attr(not(test), no_std)]
 #![cfg_attr(not(test), no_main)]
-#![cfg_attr(test, allow(unused_imports))]
-#![cfg_attr(test, allow(dead_code))]
+#![cfg_attr(test, allow(unused_imports, dead_code))]
+#![cfg_attr(not(feature = "log-serial"), allow(unused_variables, unused_imports))]
 
 #[macro_use]
 mod logger;
@@ -45,10 +45,17 @@ extern "C" {
     fn halt_loop() -> !;
 }
 
-#[cfg_attr(not(test), panic_handler)]
+#[cfg(all(not(test), feature = "log-panic"))]
+#[panic_handler]
 fn panic(info: &PanicInfo) -> ! {
     log!("PANIC: {}", info);
     unsafe { halt_loop() }
+}
+
+#[cfg(all(not(test), not(feature = "log-panic")))]
+#[panic_handler]
+fn panic(_: &PanicInfo) -> ! {
+    loop {}
 }
 
 /// Setup page tables to provide an identity mapping over the full 4GiB range

--- a/src/mmio.rs
+++ b/src/mmio.rs
@@ -14,17 +14,13 @@
 
 use crate::mem;
 
-#[cfg(not(test))]
 use crate::virtio::Error as VirtioError;
-#[cfg(not(test))]
 use crate::virtio::VirtioTransport;
 
-#[cfg(not(test))]
 pub struct VirtioMMIOTransport {
     region: mem::MemoryRegion,
 }
 
-#[cfg(not(test))]
 impl VirtioMMIOTransport {
     pub fn new(base: u64) -> VirtioMMIOTransport {
         VirtioMMIOTransport {
@@ -33,7 +29,6 @@ impl VirtioMMIOTransport {
     }
 }
 
-#[cfg(not(test))]
 impl VirtioTransport for VirtioMMIOTransport {
     fn init(&mut self, device_type: u32) -> Result<(), VirtioError> {
         const VIRTIO_MAGIC: u32 = 0x7472_6976;

--- a/src/pci.rs
+++ b/src/pci.rs
@@ -69,7 +69,7 @@ pub fn print_bus() {
             continue;
         }
         log!(
-            "Found PCI device vendor={:x} device={:x} in slot={}\n",
+            "Found PCI device vendor={:x} device={:x} in slot={}",
             vendor_id,
             device_id,
             device
@@ -151,7 +151,7 @@ impl PciDevice {
         self.device_id = device_id;
 
         log!(
-            "PCI Device: {}:{}.{} {:x}:{:x}\n",
+            "PCI Device: {}:{}.{} {:x}:{:x}",
             self.bus,
             self.device,
             self.func,
@@ -197,7 +197,7 @@ impl PciDevice {
 
         #[allow(clippy::blacklisted_name)]
         for bar in &self.bars {
-            log!("Bar: type={:?} address={:x}\n", bar.bar_type, bar.address);
+            log!("Bar: type={:?} address={:x}", bar.bar_type, bar.address);
         }
     }
 }
@@ -258,7 +258,7 @@ impl VirtioTransport for VirtioPciTransport {
 
         // bit 4 of status is capability bit
         if status & 1 << 4 == 0 {
-            log!("No capabilities detected\n");
+            log!("No capabilities detected");
             return Err(VirtioError::VirtioUnsupportedDevice);
         }
 

--- a/src/pci.rs
+++ b/src/pci.rs
@@ -14,27 +14,19 @@
 
 use cpuio::Port;
 
-#[cfg(not(test))]
 use crate::virtio::Error as VirtioError;
-#[cfg(not(test))]
 use crate::virtio::VirtioTransport;
 
 use crate::mem;
 
-#[cfg(not(test))]
 const CONFIG_ADDRESS: u16 = 0xcf8;
-#[cfg(not(test))]
 const CONFIG_DATA: u16 = 0xcfc;
 
-#[cfg(not(test))]
 const MAX_DEVICES: u8 = 32;
-#[cfg(not(test))]
 const MAX_FUNCTIONS: u8 = 8;
 
-#[cfg(not(test))]
 const INVALID_VENDOR_ID: u16 = 0xffff;
 
-#[cfg(not(test))]
 fn pci_config_read_u32(bus: u8, device: u8, func: u8, offset: u8) -> u32 {
     assert_eq!(offset % 4, 0);
     assert!(device < MAX_DEVICES);
@@ -54,18 +46,15 @@ fn pci_config_read_u32(bus: u8, device: u8, func: u8, offset: u8) -> u32 {
     config_data_port.read()
 }
 
-#[cfg(not(test))]
 fn pci_config_read_u8(bus: u8, device: u8, func: u8, offset: u8) -> u8 {
     (pci_config_read_u32(bus, device, func, offset & !3) >> ((offset % 4) * 8)) as u8
 }
 
-#[cfg(not(test))]
 fn pci_config_read_u16(bus: u8, device: u8, func: u8, offset: u8) -> u16 {
     assert_eq!(offset % 2, 0);
     (pci_config_read_u32(bus, device, func, offset & !3) >> ((offset % 4) * 8)) as u16
 }
 
-#[cfg(not(test))]
 fn get_device_details(bus: u8, device: u8, func: u8) -> (u16, u16) {
     (
         pci_config_read_u16(bus, device, func, 0),
@@ -73,7 +62,6 @@ fn get_device_details(bus: u8, device: u8, func: u8) -> (u16, u16) {
     )
 }
 
-#[cfg(not(test))]
 pub fn print_bus() {
     for device in 0..MAX_DEVICES {
         let (vendor_id, device_id) = get_device_details(0, device, 0);
@@ -89,7 +77,6 @@ pub fn print_bus() {
     }
 }
 
-#[cfg(not(test))]
 pub fn with_devices<F>(target_vendor_id: u16, target_device_id: u16, per_device: F)
 where
     F: Fn(PciDevice) -> bool,
@@ -105,7 +92,6 @@ where
     }
 }
 
-#[cfg(not(test))]
 #[derive(Default)]
 pub struct PciDevice {
     bus: u8,
@@ -116,7 +102,6 @@ pub struct PciDevice {
     device_id: u16,
 }
 
-#[cfg(not(test))]
 #[derive(Debug)]
 enum PciBarType {
     Unused,
@@ -125,21 +110,18 @@ enum PciBarType {
     IoSpace,
 }
 
-#[cfg(not(test))]
 impl Default for PciBarType {
     fn default() -> Self {
         PciBarType::Unused
     }
 }
 
-#[cfg(not(test))]
 #[derive(Default)]
 struct PciBar {
     bar_type: PciBarType,
     address: u64,
 }
 
-#[cfg(not(test))]
 impl PciDevice {
     fn new(bus: u8, device: u8, func: u8) -> PciDevice {
         PciDevice {
@@ -220,7 +202,6 @@ impl PciDevice {
     }
 }
 
-#[cfg(not(test))]
 #[allow(clippy::enum_variant_names)]
 enum VirtioPciCapabilityType {
     CommonConfig = 1,
@@ -232,7 +213,6 @@ enum VirtioPciCapabilityType {
     PciConfig = 5,
 }
 
-#[cfg(not(test))]
 #[derive(Default)]
 pub struct VirtioPciTransport {
     device: PciDevice,
@@ -242,7 +222,6 @@ pub struct VirtioPciTransport {
     device_config_region: mem::MemoryRegion, // device specific region
 }
 
-#[cfg(not(test))]
 impl VirtioPciTransport {
     pub fn new(device: PciDevice) -> VirtioPciTransport {
         VirtioPciTransport {
@@ -270,7 +249,6 @@ impl VirtioPciTransport {
 /// le64 queue_avail;               // 0x28 // read-write
 /// le64 queue_used;                // 0x30 // read-write
 
-#[cfg(not(test))]
 impl VirtioTransport for VirtioPciTransport {
     fn init(&mut self, _device_type: u32) -> Result<(), VirtioError> {
         self.device.init();

--- a/src/virtio.rs
+++ b/src/virtio.rs
@@ -13,29 +13,16 @@
 // limitations under the License.
 
 /// Virtio related errors
-#[cfg(not(test))]
 pub enum Error {
-    #[cfg(not(test))]
     VirtioMagicInvalid,
-
-    #[cfg(not(test))]
     VirtioVersionInvalid,
-
-    #[cfg(not(test))]
     VirtioUnsupportedDevice,
-
-    #[cfg(not(test))]
     VirtioLegacyOnly,
-
-    #[cfg(not(test))]
     VirtioFeatureNegotiationFailed,
-
-    #[cfg(not(test))]
     VirtioQueueTooSmall,
 }
 
 /// Trait to allow separation of transport from block driver
-#[cfg(not(test))]
 pub trait VirtioTransport {
     fn init(&mut self, device_type: u32) -> Result<(), Error>;
     fn get_status(&self) -> u32;


### PR DESCRIPTION
Depends on #23 

We only use `lazy_static` for `spin::Mutex`, but that has a `const fn` constructor, so `lazy_static` isn't needed. See the individual commits for more detailed info.

The only significant change was adding a `const fn` implementation for `Allocator::new`, as `Default::default` is never `const fn`.

Binary sizes (release build, in bytes, log-serial = true, log-panic = false):
```
Before #23:    58848
After #23:     58600
This PR + #23: 40264 (down to 31656 with no logging)
```